### PR TITLE
feat: add parse obsolete ontology flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ This operation may add about 4 minutes to the runtime for a dataset of 5M terms
 
 If `--graph` is omitted, the Gene Ontology graph is downloaded automatically.
 
+Obsolete ontologies are ignored by default when reading the ontology graph file. Add flag `--parse_obsolete` to also read obsolete terms.
+
 ### Annotation file
 The annotation file should be a tab-delimited file with headers `EntryID`, `term`, and `aspect`. 
 ```

--- a/ia.py
+++ b/ia.py
@@ -152,8 +152,8 @@ def parse_inputs(argv):
     parser.add_argument('--prop', '-p', action='store_true', 
                         help='Flag to propagate terms in annotation file according to the ontology graph')
 
-    parser.add_argument('--parse_obsolete', default=True, action=argparse.BooleanOptionalAction,
-                        help='Flag to read obsolete ontology terms in the the ontology graph.')
+    parser.add_argument('--parse_obsolete', default=False, action=argparse.BooleanOptionalAction,
+                        help='Flag to read obsolete ontology terms in the the ontology graph. False by default.')
 
     return parser.parse_args(argv)
 


### PR DESCRIPTION
The ontology graph reading by default filters out obsolete terms due to `obonet.read_obo` argument `ignore_obsolete` being `True` by default. This patch would allow the reading of obsolete terms by adding the flag `--parse_obsolete` to function calls. 